### PR TITLE
Fix unable to load 'Dimensions' package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-const Dimensions = require('Dimensions');
-const windowSize = Dimensions.get('window');
-
 import React, {
   PixelRatio,
-  Platform
+  Platform,
+  Dimensions
 } from 'react-native';
+
+const windowSize = Dimensions.get('window');
 
 class DetectDeviceService {
   constructor() {


### PR DESCRIPTION
In ReactNative v0.23 the package 'Dimensions' is not found.
